### PR TITLE
Fix anonymous messages on gratitude summaries

### DIFF
--- a/src/actions/thanks/send-gratitude-summaries.ts
+++ b/src/actions/thanks/send-gratitude-summaries.ts
@@ -10,7 +10,7 @@ import { SlackView } from "../../models/platform/slack/views/views";
 const getGratitudeSummaryMessageFrom = (gratitudeMessage: GratitudeMessage, isSender: boolean): GratitudeSummaryMessage => ({
   users: isSender ? [gratitudeMessage.recipient] : [gratitudeMessage.sender],
   text: gratitudeMessage.text.split("\n").join(" "),
-  isAnonymous: gratitudeMessage.isAnonymous,
+  isAnonymous: gratitudeMessage.isAnonymous && isSender ? false : gratitudeMessage.isAnonymous,
   createdAt: gratitudeMessage.createdAt,
 })
 

--- a/src/models/platform/slack/views/view-gratitude-summary.ts
+++ b/src/models/platform/slack/views/view-gratitude-summary.ts
@@ -9,8 +9,12 @@ export interface GratitudeSummaryViewProps {
   received?: GratitudeSummaryMessage[],
 }
 
-const toMessage = ({ users, createdAt, text }: GratitudeSummaryMessage) => {
-  return `• *${users.map(({ id }) => `<@${id}>`).join(", ")}* \`${getDateFormatted(createdAt)}\`: ${text}`;
+
+const toMessage = ({ users, createdAt, text, isAnonymous }: GratitudeSummaryMessage, i18n: I18n) => {
+  const userList = isAnonymous ? 
+                    i18n.translate("gratitudeMessageSummary.anonymous") 
+                    : users.map(({ id }) => `<@${id}>`).join(", ")
+  return `• *${userList}* \`${getDateFormatted(createdAt)}\`: ${text}`;
 }
 
 export const GratitudeSummaryView = async ({ image, sent, received }: GratitudeSummaryViewProps): Promise<SlackView> => {
@@ -37,7 +41,9 @@ export const GratitudeSummaryView = async ({ image, sent, received }: GratitudeS
       type: "section",
       text: {
         type: "mrkdwn",
-        text: hasSent ? `*${i18n.translate("gratitudeMessageSummary.sent")}*\n` + sent?.map(toMessage).join("\n") : i18n.translate("gratitudeMessageSummary.noSent")
+        text: hasSent ? 
+          `*${i18n.translate("gratitudeMessageSummary.sent")}*\n` + sent?.map(message => toMessage(message, i18n)).join("\n") 
+          : i18n.translate("gratitudeMessageSummary.noSent")
       }
     },
     { type: "divider" },
@@ -45,7 +51,9 @@ export const GratitudeSummaryView = async ({ image, sent, received }: GratitudeS
       type: "section",
       text: {
         type: "mrkdwn",
-        text: hasReceived ? `*${i18n.translate("gratitudeMessageSummary.received")}*\n` + received?.map(toMessage).join("\n") : i18n.translate("gratitudeMessageSummary.noReceived")
+        text: hasReceived ? 
+        `*${i18n.translate("gratitudeMessageSummary.received")}*\n` + received?.map(message => toMessage(message, i18n)).join("\n") 
+        : i18n.translate("gratitudeMessageSummary.noReceived")
       }
     },
     { type: "divider" },

--- a/src/services/i18n/translations/en.json
+++ b/src/services/i18n/translations/en.json
@@ -30,7 +30,8 @@
     "sentCount": "You expressed your gratitude *${count} times*",
     "received": "Received:",
     "noReceived": "You haven't received any gratitude messages this week",
-    "receivedCount": "You have received gratitude messages *${count} times*"
+    "receivedCount": "You have received gratitude messages *${count} times*",
+    "anonymous": "Anonymous"
   },
   "coffeeRoulette": {
     "searching": "We're looking for someone who'd like to have a coffee... :coffee:",

--- a/src/services/i18n/translations/es.can.json
+++ b/src/services/i18n/translations/es.can.json
@@ -30,7 +30,8 @@
     "sentCount": "Has dado las gracias *${count} veces*",
     "received": "Recibidos:",
     "noReceived": "No has recibido gracias esta semana",
-    "receivedCount": "Te han dado las gracias *${count} veces*"
+    "receivedCount": "Te han dado las gracias *${count} veces*",
+    "anonymous": "Anónimo"
   },
   "coffeeRoulette": {
     "searching": "Estamos buscando a alguien que quiera tomarse un café... :coffee:",

--- a/src/services/i18n/translations/es.json
+++ b/src/services/i18n/translations/es.json
@@ -30,7 +30,8 @@
     "sentCount": "Has dado las gracias *${count} veces*",
     "received": "Recibidos:",
     "noReceived": "No has recibido gracias esta semana",
-    "receivedCount": "Te han dado las gracias *${count} veces*"
+    "receivedCount": "Te han dado las gracias *${count} veces*",
+    "anonymous": "Anónimo"
   },
   "coffeeRoulette": {
     "searching": "Estamos buscando a alguien que quiera tomarse un café... :coffee:",


### PR DESCRIPTION
Fix gratitude summary to display anonymous messages as anonymous, instead of displaying the name of the user who sent the message.